### PR TITLE
Fix escaping bugs

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -30,16 +30,15 @@ class Element {
       return this.children.map((child) => child?.toString() ?? "").join("");
     }
 
+    const escape = (s: string): string =>
+      s.replace(/&/g, "&amp;")
+        .replace(/'/g, "&apos;")
+        .replace(/"/g, "&quot;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+
     let attributesString = Object.entries(this.attributes)
-      .map(([k, v]) => [
-        k,
-        v.replace(/&/g, "&amp;")
-          .replace(/'/g, "&apos;")
-          .replace(/"/g, "&quot;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;"),
-      ])
-      .map(([k, v]) => `${k}="${v}"`)
+      .map(([k, v]) => `${k}="${escape(v)}"`)
       .join(" ");
 
     attributesString = (attributesString.length > 0)
@@ -48,7 +47,9 @@ class Element {
 
     if (this.children.length > 0) {
       return `<${this.elementName}${attributesString}>${
-        this.children.map((child) => child?.toString() ?? "").join("")
+        this.children.map((child) =>
+          typeof child === "string" ? escape(child) : child?.toString() ?? ""
+        ).join("")
       }</${this.elementName}>`;
     } else {
       return `<${this.elementName}${attributesString}/>`;

--- a/mod.ts
+++ b/mod.ts
@@ -33,9 +33,9 @@ class Element {
     let attributesString = Object.entries(this.attributes)
       .map(([k, v]) => [
         k,
-        v.replace(/'/g, "&apos;")
+        v.replace(/&/g, "&amp;")
+          .replace(/'/g, "&apos;")
           .replace(/"/g, "&quot;")
-          .replace(/&/g, "&amp;")
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;"),
       ])

--- a/mod.ts
+++ b/mod.ts
@@ -9,6 +9,14 @@ declare global {
   }
 }
 
+function escape(s: string): string {
+  return s.replace(/&/g, "&amp;")
+    .replace(/'/g, "&apos;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 class Element {
   elementName: string | typeof fragment;
   attributes: Record<string, string>;
@@ -30,13 +38,6 @@ class Element {
       return this.children.map((child) => child?.toString() ?? "").join("");
     }
 
-    const escape = (s: string): string =>
-      s.replace(/&/g, "&amp;")
-        .replace(/'/g, "&apos;")
-        .replace(/"/g, "&quot;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;");
-
     let attributesString = Object.entries(this.attributes)
       .map(([k, v]) => `${k}="${escape(v)}"`)
       .join(" ");
@@ -46,11 +47,10 @@ class Element {
       : "";
 
     if (this.children.length > 0) {
-      return `<${this.elementName}${attributesString}>${
-        this.children.map((child) =>
-          typeof child === "string" ? escape(child) : child?.toString() ?? ""
-        ).join("")
-      }</${this.elementName}>`;
+      const value = this.children.map((child) =>
+        typeof child === "string" ? escape(child) : child?.toString() ?? ""
+      ).join("");
+      return `<${this.elementName}${attributesString}>${value}</${this.elementName}>`;
     } else {
       return `<${this.elementName}${attributesString}/>`;
     }

--- a/test/jsx.test.tsx
+++ b/test/jsx.test.tsx
@@ -26,3 +26,11 @@ Deno.test(function simpleRSS() {
     '<rss version="2.0"><channel><title>Channel Title</title><link>http://example.com</link><description>Channel Description</description><item><title>item0</title><link>http://example.com/item0/</link></item><item><title>item1</title><link>http://example.com/item1/</link></item></channel></rss>',
   );
 });
+
+Deno.test(function escapeAttributes() {
+  const v = "'\"&<>";
+  assertEquals(
+    xml.renderToString(<test foo={v} />),
+    '<test foo="&apos;&quot;&amp;&lt;&gt;"/>',
+  );
+});

--- a/test/jsx.test.tsx
+++ b/test/jsx.test.tsx
@@ -34,3 +34,11 @@ Deno.test(function escapeAttributes() {
     '<test foo="&apos;&quot;&amp;&lt;&gt;"/>',
   );
 });
+
+Deno.test(function escapeTextNodes() {
+  const v = "'\"&<test>";
+  assertEquals(
+    xml.renderToString(<test>{v}</test>),
+    "<test>&apos;&quot;&amp;&lt;test&gt;</test>",
+  );
+});


### PR DESCRIPTION
- Previously, single and double quotes were escaped to `&amp;apos;` and `&amp;quot;` respectively, which are wrong.  It's fixed by making ampersands escaped before any other characters.
- Text nodes were not escaped.  It could be vulnerable security-wise (e.g., XSS).  Now they are also escaped.

I added few regression tests too.  They fail without the above changes:

```
running 3 tests from ./test/jsx.test.tsx
simpleRSS ... ok (25ms)
escapeAttributes ... FAILED (34ms)
escapeTextNodes ... FAILED (13ms)

 ERRORS

escapeAttributes => ./test/jsx.test.tsx:30:6
error: AssertionError: Values are not equal:


    [Diff] Actual / Expected


-   <test foo="&amp;apos;&amp;quot;&amp;&lt;&gt;"/>
+   <test foo="&apos;&quot;&amp;&lt;&gt;"/>


  throw new AssertionError(message);
        ^
    at assertEquals (https://deno.land/std@0.131.0/testing/asserts.ts:269:9)
    at escapeAttributes (file:///.../aiotter/jsx4xml/test/jsx.test.tsx:32:3)

escapeTextNodes => ./test/jsx.test.tsx:38:6
error: AssertionError: Values are not equal:


    [Diff] Actual / Expected


-   <test>'"&<test></test>
+   <test>&apos;&quot;&amp;&lt;test&gt;</test>


  throw new AssertionError(message);
        ^
    at assertEquals (https://deno.land/std@0.131.0/testing/asserts.ts:269:9)
    at escapeTextNodes (file:///.../aiotter/jsx4xml/test/jsx.test.tsx:40:3)

 FAILURES

escapeAttributes => ./test/jsx.test.tsx:30:6
escapeTextNodes => ./test/jsx.test.tsx:38:6

FAILED | 1 passed | 2 failed (104ms)

error: Test failed
```

Plus: I wonder if this project is open source.  If it's open source please explicitly state the license.  Thanks!